### PR TITLE
Add async OAuth2 client credentials flow

### DIFF
--- a/httpx_auth/__init__.py
+++ b/httpx_auth/__init__.py
@@ -17,6 +17,7 @@ from httpx_auth._oauth2.authorization_code_pkce import (
 )
 from httpx_auth._oauth2.client_credentials import (
     OAuth2ClientCredentials,
+    AsyncOAuth2ClientCredentials,
     OktaClientCredentials,
 )
 from httpx_auth._oauth2.implicit import (
@@ -60,6 +61,7 @@ __all__ = [
     "OAuth2AuthorizationCode",
     "OktaAuthorizationCode",
     "OAuth2ClientCredentials",
+    "AsyncOAuth2ClientCredentials",
     "OktaClientCredentials",
     "OAuth2ResourceOwnerPasswordCredentials",
     "OktaResourceOwnerPasswordCredentials",

--- a/httpx_auth/_oauth2/client_credentials.py
+++ b/httpx_auth/_oauth2/client_credentials.py
@@ -1,12 +1,15 @@
 import copy
 from hashlib import sha512
-from typing import Union, Iterable
+from typing import Union, Iterable, AsyncGenerator
 
 import httpx
 from httpx_auth._authentication import SupportMultiAuth
+from httpx_auth._errors import AuthenticationFailed
 from httpx_auth._oauth2.common import (
+    OAuth2,
     OAuth2BaseAuth,
     request_new_grant_with_post,
+    async_request_new_grant_with_post,
     _add_parameters,
 )
 
@@ -99,6 +102,48 @@ class OAuth2ClientCredentials(OAuth2BaseAuth, SupportMultiAuth):
     def _configure_client(self, client: httpx.Client):
         client.auth = (self.client_id, self.client_secret)
         client.timeout = self.timeout
+
+
+class AsyncOAuth2ClientCredentials(OAuth2ClientCredentials):
+    """Asynchronous variant of :class:`OAuth2ClientCredentials`."""
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        try:
+            token = OAuth2.token_cache.get_token(
+                self.state, early_expiry=self.early_expiry
+            )
+        except AuthenticationFailed:
+            with OAuth2.token_cache._forbid_concurrent_missing_token_function_call:
+                try:
+                    token = OAuth2.token_cache.get_token(
+                        self.state, early_expiry=self.early_expiry
+                    )
+                except AuthenticationFailed:
+                    state, token, expires_in = await self.request_new_token()
+                    OAuth2.token_cache._add_access_token(
+                        state, token, expires_in
+                    )
+        self._update_user_request(request, token)
+        yield request
+
+    async def request_new_token(self) -> tuple:
+        client = self.client or httpx.AsyncClient()
+        self._configure_client(client)
+        try:
+            token, expires_in, _ = await async_request_new_grant_with_post(
+                self.token_url, self.data, self.token_field_name, client
+            )
+        finally:
+            if self.client is None:
+                await client.aclose()
+        return (self.state, token, expires_in)
+
+    def auth_flow(self, request: httpx.Request):  # pragma: no cover - sync not supported
+        raise RuntimeError(
+            "AsyncOAuth2ClientCredentials is only compatible with httpx.AsyncClient"
+        )
 
 
 class OktaClientCredentials(OAuth2ClientCredentials):

--- a/httpx_auth/_oauth2/common.py
+++ b/httpx_auth/_oauth2/common.py
@@ -84,6 +84,23 @@ def request_new_grant_with_post(
     return token, content.get("expires_in"), content.get("refresh_token")
 
 
+async def async_request_new_grant_with_post(
+    url: str, data, grant_name: str, client: httpx.AsyncClient
+) -> (str, int, str):
+    """Asynchronous version of :func:`request_new_grant_with_post`."""
+    response = await client.post(url, data=data)
+
+    if response.is_error:
+        # As described in https://tools.ietf.org/html/rfc6749#section-5.2
+        raise InvalidGrantRequest(response)
+
+    content = _content_from_response(response)
+    token = content.get(grant_name)
+    if not token:
+        raise GrantNotProvided(grant_name, content)
+    return token, content.get("expires_in"), content.get("refresh_token")
+
+
 class OAuth2:
     token_cache = TokenMemoryCache()
     display = DisplaySettings()

--- a/tests/oauth2/client_credential/test_oauth2_client_credential_async.py
+++ b/tests/oauth2/client_credential/test_oauth2_client_credential_async.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 
 from pytest_httpx import HTTPXMock
 import pytest
@@ -13,106 +13,104 @@ from httpx_auth._oauth2.tokens import to_expiry
 async def test_oauth2_client_credentials_flow_uses_provided_client(
     token_cache, httpx_mock: HTTPXMock
 ):
-    # TODO Add support for AsyncClient
-    client = httpx.Client(headers={"x-test": "Test value"})
-    auth = httpx_auth.OAuth2ClientCredentials(
-        "https://provide_access_token",
-        client_id="test_user",
-        client_secret="test_pwd",
-        client=client,
-    )
-    httpx_mock.add_response(
-        method="POST",
-        url="https://provide_access_token",
-        json={
-            "access_token": "2YotnFZFEjr1zCsicMWpAA",
-            "token_type": "example",
-            "expires_in": 3600,
-            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
-            "example_parameter": "example_value",
-        },
-        match_headers={"x-test": "Test value"},
-        match_content=b"grant_type=client_credentials",
-    )
-    httpx_mock.add_response(
-        url="https://authorized_only",
-        method="GET",
-        match_headers={
-            "Authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA",
-        },
-    )
+    async with httpx.AsyncClient(headers={"x-test": "Test value"}) as oauth_client:
+        auth = httpx_auth.AsyncOAuth2ClientCredentials(
+            "https://provide_access_token",
+            client_id="test_user",
+            client_secret="test_pwd",
+            client=oauth_client,
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://provide_access_token",
+            json={
+                "access_token": "2YotnFZFEjr1zCsicMWpAA",
+                "token_type": "example",
+                "expires_in": 3600,
+                "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+                "example_parameter": "example_value",
+            },
+            match_headers={"x-test": "Test value"},
+            match_content=b"grant_type=client_credentials",
+        )
+        httpx_mock.add_response(
+            url="https://authorized_only",
+            method="GET",
+            match_headers={
+                "Authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA",
+            },
+        )
 
-    async with httpx.AsyncClient() as client:
-        await client.get("https://authorized_only", auth=auth)
+        async with httpx.AsyncClient() as client:
+            await client.get("https://authorized_only", auth=auth)
 
 
 @pytest.mark.asyncio
 async def test_oauth2_client_credentials_flow_is_able_to_reuse_client(
     token_cache, httpx_mock: HTTPXMock
 ):
-    # TODO Add support for AsyncClient
-    client = httpx.Client(headers={"x-test": "Test value"})
-    auth = httpx_auth.OAuth2ClientCredentials(
-        "https://provide_access_token",
-        client_id="test_user",
-        client_secret="test_pwd",
-        client=client,
-    )
-    httpx_mock.add_response(
-        method="POST",
-        url="https://provide_access_token",
-        json={
-            "access_token": "2YotnFZFEjr1zCsicMWpAA",
-            "token_type": "example",
-            "expires_in": 2,
-            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
-            "example_parameter": "example_value",
-        },
-        match_headers={"x-test": "Test value"},
-        match_content=b"grant_type=client_credentials",
-    )
-    httpx_mock.add_response(
-        url="https://authorized_only",
-        method="GET",
-        match_headers={
-            "Authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA",
-        },
-    )
+    async with httpx.AsyncClient(headers={"x-test": "Test value"}) as oauth_client:
+        auth = httpx_auth.AsyncOAuth2ClientCredentials(
+            "https://provide_access_token",
+            client_id="test_user",
+            client_secret="test_pwd",
+            client=oauth_client,
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://provide_access_token",
+            json={
+                "access_token": "2YotnFZFEjr1zCsicMWpAA",
+                "token_type": "example",
+                "expires_in": 2,
+                "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+                "example_parameter": "example_value",
+            },
+            match_headers={"x-test": "Test value"},
+            match_content=b"grant_type=client_credentials",
+        )
+        httpx_mock.add_response(
+            url="https://authorized_only",
+            method="GET",
+            match_headers={
+                "Authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA",
+            },
+        )
 
-    async with httpx.AsyncClient() as client:
-        await client.get("https://authorized_only", auth=auth)
+        async with httpx.AsyncClient() as client:
+            await client.get("https://authorized_only", auth=auth)
 
-    time.sleep(2)
+        await asyncio.sleep(2)
 
-    httpx_mock.add_response(
-        method="POST",
-        url="https://provide_access_token",
-        json={
-            "access_token": "2YotnFZFEjr1zCsicMWpAA",
-            "token_type": "example",
-            "expires_in": 10,
-            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
-            "example_parameter": "example_value",
-        },
-        match_headers={"x-test": "Test value"},
-        match_content=b"grant_type=client_credentials",
-    )
-    httpx_mock.add_response(
-        url="https://authorized_only",
-        method="GET",
-        match_headers={
-            "Authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA",
-        },
-    )
-    async with httpx.AsyncClient() as client:
-        await client.get("https://authorized_only", auth=auth)
+        httpx_mock.add_response(
+            method="POST",
+            url="https://provide_access_token",
+            json={
+                "access_token": "2YotnFZFEjr1zCsicMWpAA",
+                "token_type": "example",
+                "expires_in": 10,
+                "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+                "example_parameter": "example_value",
+            },
+            match_headers={"x-test": "Test value"},
+            match_content=b"grant_type=client_credentials",
+        )
+        httpx_mock.add_response(
+            url="https://authorized_only",
+            method="GET",
+            match_headers={
+                "Authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA",
+            },
+        )
+        async with httpx.AsyncClient() as client:
+            await client.get("https://authorized_only", auth=auth)
 
 
 @pytest.mark.asyncio
 async def test_oauth2_client_credentials_flow_token_is_sent_in_authorization_header_by_default(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -143,7 +141,7 @@ async def test_oauth2_client_credentials_flow_token_is_sent_in_authorization_hea
 async def test_oauth2_client_credentials_flow_token_is_expired_after_30_seconds_by_default(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     # Add a token that expires in 29 seconds, so should be considered as expired when issuing the request
@@ -181,7 +179,7 @@ async def test_oauth2_client_credentials_flow_token_is_expired_after_30_seconds_
 async def test_oauth2_client_credentials_flow_token_custom_expiry(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token",
         client_id="test_user",
         client_secret="test_pwd",
@@ -207,7 +205,7 @@ async def test_oauth2_client_credentials_flow_token_custom_expiry(
 
 @pytest.mark.asyncio
 async def test_expires_in_sent_as_str(token_cache, httpx_mock: HTTPXMock):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -236,7 +234,7 @@ async def test_expires_in_sent_as_str(token_cache, httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_with_invalid_grant_request_no_json(token_cache, httpx_mock: HTTPXMock):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -255,7 +253,7 @@ async def test_with_invalid_grant_request_no_json(token_cache, httpx_mock: HTTPX
 async def test_with_invalid_grant_request_invalid_request_error(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -283,7 +281,7 @@ async def test_with_invalid_grant_request_invalid_request_error(
 async def test_with_invalid_grant_request_invalid_request_error_and_error_description(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -305,7 +303,7 @@ async def test_with_invalid_grant_request_invalid_request_error_and_error_descri
 async def test_with_invalid_grant_request_invalid_request_error_and_error_description_and_uri(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -334,7 +332,7 @@ async def test_with_invalid_grant_request_invalid_request_error_and_error_descri
 async def test_with_invalid_grant_request_invalid_request_error_and_error_description_and_uri_and_other_fields(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -364,7 +362,7 @@ async def test_with_invalid_grant_request_invalid_request_error_and_error_descri
 async def test_with_invalid_grant_request_without_error(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -386,7 +384,7 @@ async def test_with_invalid_grant_request_without_error(
 async def test_with_invalid_grant_request_invalid_client_error(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -418,7 +416,7 @@ async def test_with_invalid_grant_request_invalid_client_error(
 async def test_with_invalid_grant_request_invalid_grant_error(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -446,7 +444,7 @@ async def test_with_invalid_grant_request_invalid_grant_error(
 async def test_with_invalid_grant_request_unauthorized_client_error(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -472,7 +470,7 @@ async def test_with_invalid_grant_request_unauthorized_client_error(
 async def test_with_invalid_grant_request_unsupported_grant_type_error(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -498,7 +496,7 @@ async def test_with_invalid_grant_request_unsupported_grant_type_error(
 async def test_with_invalid_grant_request_invalid_scope_error(
     token_cache, httpx_mock: HTTPXMock
 ):
-    auth = httpx_auth.OAuth2ClientCredentials(
+    auth = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token", client_id="test_user", client_secret="test_pwd"
     )
     httpx_mock.add_response(
@@ -538,12 +536,12 @@ async def test_oauth2_client_credentials_flow_handle_credentials_as_part_of_cach
     client_id2,
     client_secret2,
 ):
-    auth1 = httpx_auth.OAuth2ClientCredentials(
+    auth1 = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token",
         client_id=client_id1,
         client_secret=client_secret1,
     )
-    auth2 = httpx_auth.OAuth2ClientCredentials(
+    auth2 = httpx_auth.AsyncOAuth2ClientCredentials(
         "https://provide_access_token",
         client_id=client_id2,
         client_secret=client_secret2,


### PR DESCRIPTION
## Summary
- add async_request_new_grant_with_post to handle token acquisition with `httpx.AsyncClient`
- introduce AsyncOAuth2ClientCredentials for non-blocking client credentials grant
- update async client credentials tests to use async client and new auth class

## Testing
- `pytest tests/oauth2/client_credential/test_oauth2_client_credential_async.py::test_oauth2_client_credentials_flow_uses_provided_client -q` *(fails: Unknown config option: asyncio_default_fixture_loop_scope)*
- `pip install pytest-asyncio` *(fails: Could not find a version that satisfies the requirement pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_689f9c96aea48333956ba2f343a3f928